### PR TITLE
update docs - replace  deprecated command session.New

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ import (
 )
 
 func main() {
-	svc := dynamodb.New(session.New(), &aws.Config{
-		Region:   aws.String("us-west-2"),
-	})
+    svc := dynamodb.New(session.Must(session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2"),
+    })))
 	c, err := dynamolock.New(svc,
 		"locks",
 		dynamolock.WithLeaseDuration(3*time.Second),
@@ -93,7 +93,7 @@ func main() {
 
 	log.Println("lock content:", string(lockedItem.Data()))
 	if got := string(lockedItem.Data()); string(data) != got {
-		t.Error("losing information inside lock storage, wanted:", string(data), " got:", got)
+		log.Println("losing information inside lock storage, wanted:", string(data), " got:", got)
 	}
 
 	log.Println("cleaning lock")

--- a/doc.go
+++ b/doc.go
@@ -34,9 +34,9 @@ limitations under the License.
 //
 //	// ---
 //
-//	svc := dynamodb.New(session.New(), &aws.Config{
-//		Region:   aws.String("us-west-2"),
-//	})
+//	svc := dynamodb.New(session.Must(session.NewSession(&aws.Config{
+//		Region: aws.String("us-west-2"),
+//	})))
 //	c, err := dynamolock.New(svc,
 //		"locks",
 //		dynamolock.WithLeaseDuration(3*time.Second),


### PR DESCRIPTION
The code examples uses a deprecated command `session.New()`. It should be replace with `session.NewSession(...`. 

There is also a diff between `doc.go` and `README` for the output command in code example section of lock content.