### PR TITLE
Don't wrap LockNotGrantedError in error.errorString

### DIFF
--- a/client.go
+++ b/client.go
@@ -538,8 +538,7 @@ func (c *Client) putLockItemAndStartSessionMonitor(
 
 	_, err := c.dynamoDB.PutItem(putItemRequest)
 	if err != nil {
-		err := parseDynamoDBError(err, "lock already acquired by other client")
-		return nil, fmt.Errorf("cannot store lock item: %s", err)
+		return nil, parseDynamoDBError(err, "cannot store lock item: lock already acquired by other client")
 	}
 
 	lockItem := &Lock{


### PR DESCRIPTION
This eases the error handling in the callers code. The old implementation had an information loss. It was not easy to check if the error was simple cased by someone else grapping the lock.