### PR TITLE
add channel-based expiration check

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -77,6 +77,14 @@ func (l *Lock) IsExpired() bool {
 	return l.isExpired()
 }
 
+// Expiration returns a channel into which the time will be sent upon expiration.
+func (l *Lock) Expiration() <-chan time.Time {
+	if l == nil {
+		return time.After(0)
+	}
+	return time.After(l.leaseDuration - time.Since(l.lookupTime))
+}
+
 func (l *Lock) isExpired() bool {
 	if l == nil {
 		return true


### PR DESCRIPTION
This is a small concrete proposal to fix #42 by adding `lock.Expiration()` method, which returns a `time.Time` channel for the expiration time. It does not attempt to use the internal semaphore and check `isReleased` because it would defeat the main goal of a channel based solution (avoiding polling).

PTAL