### PR TITLE
Export isLockNotGrantedError

### DIFF
--- a/client.go
+++ b/client.go
@@ -387,7 +387,7 @@ func (c *Client) storeLock(ctx context.Context, getLockOptions *getLockOptions) 
 			item,
 			recordVersionNumber,
 			getLockOptions.sessionMonitor)
-		if err != nil && isLockNotGrantedError(err) {
+		if err != nil && IsLockNotGrantedError(err) {
 			return nil, nil
 		}
 		return l, err
@@ -424,7 +424,7 @@ func (c *Client) storeLock(ctx context.Context, getLockOptions *getLockOptions) 
 			existingLock, newLockData, item,
 			recordVersionNumber,
 			getLockOptions.sessionMonitor)
-		if err != nil && isLockNotGrantedError(err) {
+		if err != nil && IsLockNotGrantedError(err) {
 			return nil, nil
 		}
 		return l, err

--- a/client_heartbeat.go
+++ b/client_heartbeat.go
@@ -123,7 +123,7 @@ func (c *Client) sendHeartbeat(ctx context.Context, options *sendHeartbeatOption
 	_, err := c.dynamoDB.UpdateItemWithContext(ctx, updateItemInput)
 	if err != nil {
 		err := parseDynamoDBError(err, "already acquired lock, stopping heartbeats")
-		if isLockNotGrantedError(err) {
+		if IsLockNotGrantedError(err) {
 			c.locks.Delete(lockItem.uniqueIdentifier())
 		}
 		return err

--- a/errors.go
+++ b/errors.go
@@ -54,7 +54,7 @@ func (e *LockNotGrantedError) Unwrap() error {
 	return e.cause
 }
 
-func isLockNotGrantedError(err error) bool {
+func IsLockNotGrantedError(err error) bool {
 	_, ok := err.(*LockNotGrantedError)
 	return ok
 }

--- a/errors_internal_test.go
+++ b/errors_internal_test.go
@@ -30,11 +30,11 @@ func TestLockNotGrantedError(t *testing.T) {
 	t.Parallel()
 	t.Run("simply not granted", func(t *testing.T) {
 		notGranted := &LockNotGrantedError{msg: "not granted"}
-		if !isLockNotGrantedError(notGranted) {
+		if !IsLockNotGrantedError(notGranted) {
 			t.Error("mismatched error type check: ", notGranted)
 		}
 		vanilla := errors.New("vanilla error")
-		if isLockNotGrantedError(vanilla) {
+		if IsLockNotGrantedError(vanilla) {
 			t.Error("mismatched error type check: ", vanilla)
 		}
 	})


### PR DESCRIPTION
I would like to suggest that `isLockNotGrantedError` is exported. I believe it is useful to have when instrumenting a tool with this library. I know the method is easy to implement, but I think it would encourage a tighter coupling.