### PR TITLE
Adds context to logger interface.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -590,7 +590,9 @@ func TestCustomRefreshPeriod(t *testing.T) {
 		Region:   aws.String("us-west-2"),
 	})
 	var buf bytes.Buffer
-	logger := log.New(&buf, "", 0)
+	logger := &dynamolock.DefaultLogger{
+		Logger: log.New(&buf, "", 0),
+	}
 	c, err := dynamolock.New(svc,
 		"locks",
 		dynamolock.WithLeaseDuration(3*time.Second),
@@ -867,7 +869,7 @@ type testLogger struct {
 	t *testing.T
 }
 
-func (t *testLogger) Println(v ...interface{}) {
+func (t *testLogger) Println(_ context.Context, v ...interface{}) {
 	t.t.Helper()
 	t.t.Log(v...)
 }
@@ -945,7 +947,9 @@ func TestHeartbeatError(t *testing.T) {
 	defer func() {
 		t.Log(buf.String())
 	}()
-	logger := log.New(&buf, "", 0)
+	logger := &dynamolock.DefaultLogger{
+		Logger: log.New(&buf, "", 0),
+	}
 
 	heartbeatPeriod := 2 * time.Second
 	c, err := dynamolock.New(svc,

--- a/client_test.go
+++ b/client_test.go
@@ -590,9 +590,7 @@ func TestCustomRefreshPeriod(t *testing.T) {
 		Region:   aws.String("us-west-2"),
 	})
 	var buf bytes.Buffer
-	logger := &dynamolock.DefaultLogger{
-		Logger: log.New(&buf, "", 0),
-	}
+	logger := log.New(&buf, "", 0)
 	c, err := dynamolock.New(svc,
 		"locks",
 		dynamolock.WithLeaseDuration(3*time.Second),
@@ -869,7 +867,7 @@ type testLogger struct {
 	t *testing.T
 }
 
-func (t *testLogger) Println(_ context.Context, v ...interface{}) {
+func (t *testLogger) Println(v ...interface{}) {
 	t.t.Helper()
 	t.t.Log(v...)
 }
@@ -947,9 +945,7 @@ func TestHeartbeatError(t *testing.T) {
 	defer func() {
 		t.Log(buf.String())
 	}()
-	logger := &dynamolock.DefaultLogger{
-		Logger: log.New(&buf, "", 0),
-	}
+	logger := log.New(&buf, "", 0)
 
 	heartbeatPeriod := 2 * time.Second
 	c, err := dynamolock.New(svc,


### PR DESCRIPTION
Hi @ucirello ! Thanks so much for making this library! 

This PR adds context to the logging interface. The use case that we're running into is that with the current interface, there's no way to add a correlation id to the log line. This makes it almost impossible for us to consume dynamolock's log output in any meaningful way.

I saw that you don't promise backwards compatibility, but I'm happy to re-do this in a backwards compatible way if desired. Thank you!