### PR TITLE
Removed WithCustomPartitionKeyName

### DIFF
--- a/client.go
+++ b/client.go
@@ -712,7 +712,7 @@ func (c *Client) CreateTableWithContext(ctx context.Context, tableName string, o
 	createTableOptions := &createDynamoDBTableOptions{
 		tableName:        tableName,
 		billingMode:      "PAY_PER_REQUEST",
-		partitionKeyName: defaultPartitionKeyName,
+		partitionKeyName: c.partitionKeyName,
 	}
 	for _, opt := range opts {
 		opt(createTableOptions)
@@ -725,14 +725,6 @@ func (c *Client) CreateTableWithContext(ctx context.Context, tableName string, o
 // client-compatible and specify optional parameters such as the desired
 // throughput and whether or not to use a sort key.
 type CreateTableOption func(*createDynamoDBTableOptions)
-
-// WithCustomPartitionKeyName changes the partition key name of the table. If
-// not specified, the default "key" will be used.
-func WithCustomPartitionKeyName(s string) CreateTableOption {
-	return func(opt *createDynamoDBTableOptions) {
-		opt.partitionKeyName = s
-	}
-}
 
 // WithTags changes the tags of the table. If not specified, the table will have empty tags.
 func WithTags(tags []*dynamodb.Tag) CreateTableOption {

--- a/client_bugs_test.go
+++ b/client_bugs_test.go
@@ -49,7 +49,6 @@ func TestIssue56(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (

--- a/client_heartbeat_test.go
+++ b/client_heartbeat_test.go
@@ -73,7 +73,6 @@ func TestHeartbeatHandover(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content a")
@@ -170,7 +169,6 @@ func TestHeartbeatDataOps(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("delete data on heartbeat", func(t *testing.T) {

--- a/client_session_monitor_test.go
+++ b/client_session_monitor_test.go
@@ -50,7 +50,6 @@ func TestSessionMonitor(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (
@@ -107,7 +106,6 @@ func TestSessionMonitorRemoveBeforeExpiration(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (
@@ -163,7 +161,6 @@ func TestSessionMonitorFullCycle(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (

--- a/client_test.go
+++ b/client_test.go
@@ -76,7 +76,6 @@ func TestClientBasicFlow(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content a")
@@ -177,7 +176,6 @@ func TestReadLockContent(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
 			}),
-			dynamolock.WithCustomPartitionKeyName("key"),
 		)
 
 		data := []byte("some content a")
@@ -238,7 +236,6 @@ func TestReadLockContent(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
 			}),
-			dynamolock.WithCustomPartitionKeyName("key"),
 		)
 
 		data := []byte("hello janice")
@@ -284,7 +281,6 @@ func TestReadLockContentAfterRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content for scotty")
@@ -349,7 +345,6 @@ func TestReadLockContentAfterDeleteOnRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content for uhura")
@@ -431,7 +426,6 @@ func TestFailIfLocked(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	_, err = c.AcquireLock("failIfLocked")
@@ -469,7 +463,6 @@ func TestClientWithAdditionalAttributes(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("good attributes", func(t *testing.T) {
@@ -552,7 +545,6 @@ func TestDeleteLockOnRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "delete-lock-on-release"
@@ -609,7 +601,6 @@ func TestCustomRefreshPeriod(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	lockedItem, err := c.AcquireLock("custom-refresh-period")
@@ -649,7 +640,6 @@ func TestCustomAdditionalTimeToWaitForLock(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Log("acquire lock")
@@ -698,7 +688,6 @@ func TestClientClose(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Log("acquiring locks")
@@ -771,7 +760,6 @@ func TestInvalidReleases(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("release nil lock", func(t *testing.T) {
@@ -838,7 +826,6 @@ func TestClientWithDataAfterRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "lockNoData"
@@ -898,7 +885,6 @@ func TestHeartbeatLoss(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "heartbeatLoss"
@@ -966,7 +952,6 @@ func TestHeartbeatError(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 	if err != nil {
 		fatal("cannot create table")


### PR DESCRIPTION
The `Client` already knows the `partitionKeyName`, so it does not need to be supplied to `CreateTable`.
