### PR TITLE
dynamolock/v3: Removed WithCustomPartitionKeyName

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -78,7 +78,6 @@ func main() {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/v3/client.go
+++ b/v3/client.go
@@ -679,7 +679,7 @@ func (c *Client) CreateTableWithContext(ctx context.Context, tableName string, o
 	createTableOptions := &createDynamoDBTableOptions{
 		tableName:        tableName,
 		billingMode:      "PAY_PER_REQUEST",
-		partitionKeyName: defaultPartitionKeyName,
+		partitionKeyName: c.partitionKeyName,
 	}
 	for _, opt := range opts {
 		opt(createTableOptions)
@@ -692,14 +692,6 @@ func (c *Client) CreateTableWithContext(ctx context.Context, tableName string, o
 // client-compatible and specify optional parameters such as the desired
 // throughput and whether or not to use a sort key.
 type CreateTableOption func(*createDynamoDBTableOptions)
-
-// WithCustomPartitionKeyName changes the partition key name of the table. If
-// not specified, the default "key" will be used.
-func WithCustomPartitionKeyName(s string) CreateTableOption {
-	return func(opt *createDynamoDBTableOptions) {
-		opt.partitionKeyName = s
-	}
-}
 
 // WithTags changes the tags of the table. If not specified, the table will have empty tags.
 func WithTags(tags []types.Tag) CreateTableOption {

--- a/v3/client_bugs_test.go
+++ b/v3/client_bugs_test.go
@@ -46,7 +46,6 @@ func TestIssue56(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(1000),
 			WriteCapacityUnits: aws.Int64(1000),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (

--- a/v3/client_heartbeat_test.go
+++ b/v3/client_heartbeat_test.go
@@ -66,7 +66,6 @@ func TestHeartbeatHandover(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content a")
@@ -159,7 +158,6 @@ func TestHeartbeatDataOps(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("delete data on heartbeat", func(t *testing.T) {

--- a/v3/client_session_monitor_test.go
+++ b/v3/client_session_monitor_test.go
@@ -47,7 +47,6 @@ func TestSessionMonitor(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (
@@ -100,7 +99,6 @@ func TestSessionMonitorRemoveBeforeExpiration(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (
@@ -152,7 +150,6 @@ func TestSessionMonitorFullCycle(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	var (

--- a/v3/client_test.go
+++ b/v3/client_test.go
@@ -105,7 +105,6 @@ func TestClientBasicFlow(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content a")
@@ -202,7 +201,6 @@ func TestReadLockContent(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
 			}),
-			dynamolock.WithCustomPartitionKeyName("key"),
 		)
 
 		data := []byte("some content a")
@@ -260,7 +258,6 @@ func TestReadLockContent(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
 			}),
-			dynamolock.WithCustomPartitionKeyName("key"),
 		)
 
 		data := []byte("hello janice")
@@ -302,7 +299,6 @@ func TestReadLockContentAfterRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content for scotty")
@@ -363,7 +359,6 @@ func TestReadLockContentAfterDeleteOnRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	data := []byte("some content for uhura")
@@ -437,7 +432,6 @@ func TestFailIfLocked(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	_, err = c.AcquireLock("failIfLocked")
@@ -471,7 +465,6 @@ func TestClientWithAdditionalAttributes(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("good attributes", func(t *testing.T) {
@@ -550,7 +543,6 @@ func TestDeleteLockOnRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "delete-lock-on-release"
@@ -603,7 +595,6 @@ func TestCustomRefreshPeriod(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	lockedItem, err := c.AcquireLock("custom-refresh-period")
@@ -639,7 +630,6 @@ func TestCustomAdditionalTimeToWaitForLock(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Log("acquire lock")
@@ -684,7 +674,6 @@ func TestClientClose(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Log("acquiring locks")
@@ -753,7 +742,6 @@ func TestInvalidReleases(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	t.Run("release nil lock", func(t *testing.T) {
@@ -816,7 +804,6 @@ func TestClientWithDataAfterRelease(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "lockNoData"
@@ -872,7 +859,6 @@ func TestHeartbeatLoss(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 
 	const lockName = "heartbeatLoss"
@@ -936,7 +922,6 @@ func TestHeartbeatError(t *testing.T) {
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
 		}),
-		dynamolock.WithCustomPartitionKeyName("key"),
 	)
 	if err != nil {
 		fatal("cannot create table", err)

--- a/v3/doc.go
+++ b/v3/doc.go
@@ -55,7 +55,6 @@ limitations under the License.
 //			ReadCapacityUnits:  aws.Int64(5),
 //			WriteCapacityUnits: aws.Int64(5),
 //		}),
-//		dynamolock.WithCustomPartitionKeyName("key"),
 //	)
 //
 //  //-- at this point you must wait for DynamoDB to complete the creation.


### PR DESCRIPTION
The `Client` already knows the `partitionKeyName`, so it does not need to be supplied to `CreateTable`.
