### PR TITLE
Use `internalClient` internally instead of `Client`

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -53,7 +53,6 @@ var (
 
 var isReleasedAttrVal = expression.Value("1")
 
-// Client is a dynamoDB based distributed lock client.
 type internalClient struct {
 	dynamoDB DynamoDBClient
 
@@ -75,6 +74,7 @@ type internalClient struct {
 	closed    bool
 }
 
+// Client is a dynamoDB based distributed lock client.
 type Client struct{ *internalClient }
 
 const (

--- a/v3/client_heartbeat.go
+++ b/v3/client_heartbeat.go
@@ -56,7 +56,7 @@ func ReplaceHeartbeatData(data []byte) SendHeartbeatOption {
 // is unnecessary, because the background thread will be periodically calling it
 // and sending heartbeats. However, if WithHeartbeatPeriod = 0, then this method
 // must be called to instruct DynamoDB that the lock should not be expired.
-func (c *Client) SendHeartbeat(lockItem *Lock, opts ...SendHeartbeatOption) error {
+func (c *internalClient) SendHeartbeat(lockItem *Lock, opts ...SendHeartbeatOption) error {
 	return c.SendHeartbeatWithContext(context.Background(), lockItem, opts...)
 }
 
@@ -66,7 +66,7 @@ func (c *Client) SendHeartbeat(lockItem *Lock, opts ...SendHeartbeatOption) erro
 // calling it and sending heartbeats. However, if WithHeartbeatPeriod = 0, then
 // this method must be called to instruct DynamoDB that the lock should not be
 // expired. The given context is passed down to the underlying dynamoDB call.
-func (c *Client) SendHeartbeatWithContext(ctx context.Context, lockItem *Lock, opts ...SendHeartbeatOption) error {
+func (c *internalClient) SendHeartbeatWithContext(ctx context.Context, lockItem *Lock, opts ...SendHeartbeatOption) error {
 	if c.isClosed() {
 		return ErrClientClosed
 	}
@@ -79,7 +79,7 @@ func (c *Client) SendHeartbeatWithContext(ctx context.Context, lockItem *Lock, o
 	return c.sendHeartbeat(ctx, sho)
 }
 
-func (c *Client) sendHeartbeat(ctx context.Context, options *sendHeartbeatOptions) error {
+func (c *internalClient) sendHeartbeat(ctx context.Context, options *sendHeartbeatOptions) error {
 	leaseDuration := c.leaseDuration
 
 	lockItem := options.lockItem

--- a/v3/client_internal_test.go
+++ b/v3/client_internal_test.go
@@ -96,7 +96,7 @@ func TestCloseRace(t *testing.T) {
 }
 
 func TestBadCreateLockItem(t *testing.T) {
-	c := &Client{}
+	c := &Client{&internalClient{}}
 	_, err := c.createLockItem(getLockOptions{}, map[string]types.AttributeValue{
 		attrLeaseDuration: stringAttrValue("bad duration"),
 	})

--- a/v3/lock.go
+++ b/v3/lock.go
@@ -28,7 +28,7 @@ import (
 type Lock struct {
 	semaphore sync.Mutex
 
-	client       *Client
+	client       *internalClient
 	partitionKey string
 
 	data                []byte


### PR DESCRIPTION
Both `Client` and the eventual `ClientWithSortKey` are wrappers around `internalClient`, which is what the current `Client` is. This allows us to keep much of the shared functionality the same between the two types, and only changing a handful of method signatures where a sort key must be present.

This commit shouldn't functionally change anything, as it's simply updating method signatures.
