### PR TITLE
Add ClientWithSortKey in.

### DIFF
--- a/v3/client_heartbeat.go
+++ b/v3/client_heartbeat.go
@@ -98,7 +98,7 @@ func (c *internalClient) sendHeartbeat(ctx context.Context, options *sendHeartbe
 
 	newRvn := c.generateRecordVersionNumber()
 
-	cond := ownershipLockCondition(c.partitionKeyName, lockItem.recordVersionNumber, lockItem.ownerName)
+	cond := ownershipLockCondition(c.partitionKeyName, c.sortKeyName, lockItem.recordVersionNumber, lockItem.ownerName)
 	update := expression.
 		Set(leaseDurationAttr, expression.Value(leaseDuration.String())).
 		Set(rvnAttr, expression.Value(newRvn))

--- a/v3/structs.go
+++ b/v3/structs.go
@@ -24,6 +24,7 @@ import (
 
 type acquireLockOptions struct {
 	partitionKey                string
+	sortKey                     string
 	data                        []byte
 	replaceData                 bool
 	deleteLockOnRelease         bool
@@ -35,7 +36,8 @@ type acquireLockOptions struct {
 }
 
 type getLockOptions struct {
-	partitionKeyName                  string
+	partitionKey                      string
+	sortKey                           string
 	deleteLockOnRelease               bool
 	millisecondsToWait                time.Duration
 	refreshPeriodDuration             time.Duration
@@ -60,5 +62,6 @@ type createDynamoDBTableOptions struct {
 	provisionedThroughput *types.ProvisionedThroughput
 	tableName             string
 	partitionKeyName      string
+	sortKeyName           string
 	tags                  []types.Tag
 }


### PR DESCRIPTION
This commit introduces `ClientWithSortKey`, as well as updating the method signatures of `internalClient` to include a `sortKey` parameter. These parameters are currently just passed through to other functions, but don't actually affect anything (other than log messages).

I have inserted `// TODO`s throughout the code where I will be updating the business logic in the next PR.