### PR TITLE
Make the key variable naming scheme consistent.

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -36,8 +36,8 @@ func New(dynamoDB DynamoDBClient, tableName string, opts ...ClientOption) (*Clie
 
 // AcquireLockWithContext holds the defined lock. The given context is passed
 // down to the underlying dynamoDB call.
-func (c *Client) AcquireLockWithContext(ctx context.Context, key string, opts ...AcquireLockOption) (*Lock, error) {
-	return c.acquireLockWithContext(ctx, key, opts...)
+func (c *Client) AcquireLockWithContext(ctx context.Context, partitionKey string, opts ...AcquireLockOption) (*Lock, error) {
+	return c.acquireLockWithContext(ctx, partitionKey, opts...)
 }
 
 // GetWithContext finds out who owns the given lock, but does not acquire the
@@ -49,8 +49,8 @@ func (c *Client) AcquireLockWithContext(ctx context.Context, key string, opts ..
 // has the lock.) If the context is canceled, it is going to return the context
 // error on local cache hit. The given context is passed down to the underlying
 // dynamoDB call.
-func (c *Client) GetWithContext(ctx context.Context, key string) (*Lock, error) {
-	return c.getWithContext(ctx, key)
+func (c *Client) GetWithContext(ctx context.Context, partitionKey string) (*Lock, error) {
+	return c.getWithContext(ctx, partitionKey)
 }
 
 // Sugar functions
@@ -62,11 +62,11 @@ func (c *Client) GetWithContext(ctx context.Context, key string) (*Lock, error) 
 // operations like releaseLock will not work (after calling Get, the caller
 // should check lockItem.isExpired() to figure out if it currently has the
 // lock.)
-func (c *Client) Get(key string) (*Lock, error) {
-	return c.GetWithContext(context.Background(), key)
+func (c *Client) Get(partitionKey string) (*Lock, error) {
+	return c.GetWithContext(context.Background(), partitionKey)
 }
 
 // AcquireLock holds the defined lock.
-func (c *Client) AcquireLock(key string, opts ...AcquireLockOption) (*Lock, error) {
-	return c.AcquireLockWithContext(context.Background(), key, opts...)
+func (c *Client) AcquireLock(partitionKey string, opts ...AcquireLockOption) (*Lock, error) {
+	return c.AcquireLockWithContext(context.Background(), partitionKey, opts...)
 }

--- a/v3/structs.go
+++ b/v3/structs.go
@@ -35,7 +35,7 @@ type acquireLockOptions struct {
 }
 
 type getLockOptions struct {
-	partitionKeyName                  string
+	partitionKey                      string
 	deleteLockOnRelease               bool
 	millisecondsToWait                time.Duration
 	refreshPeriodDuration             time.Duration


### PR DESCRIPTION
Currently, the variable naming scheme for keys is to call the partition key's name itself `partitionKeyName`, and its value `key`. Since we'll be introducing a sort key, I propose we rename all relevant `key` variables to `partitionKey` instead. This way, later on we can add in a `sortKeyName` and `sortKey` pair.

There's a few places where `key` is used as a variable name which I left untouched (eg within `releaseLock`). These keys will eventually be a combination of both the partition and sort keys, so it makes sense to keep their name generic.

Additionally, the `getLockOptions` struct had a field named `partitionKeyName`, but which was being used to store a simple partition key. As such, I renamed it to `partitionKey`, to be consistent with the other uses of the name `partitionKey`.