### PR TITLE
Add in ClientWithSortKey.

### DIFF
--- a/v3/client_sortkey.go
+++ b/v3/client_sortkey.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 U. Cirello (cirello.io and github.com/cirello-io)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamolock
+
+import (
+	"context"
+	"errors"
+)
+
+// ClientWithSortKey is a dynamoDB based distributed lock client, but with a required sort key.
+type ClientWithSortKey struct{ *internalClient }
+
+// NewWithSortKey creates a new dynamoDB based distributed lock client.
+func NewWithSortKey(dynamoDB DynamoDBClient, tableName, sortKeyName string, opts ...ClientOption) (*ClientWithSortKey, error) {
+	if sortKeyName == "" {
+		return nil, errors.New("a sortKeyName must be supplied; use `Client` if you don't want a sort key")
+	}
+
+	internalClient, err := newInternal(dynamoDB, tableName, opts...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientWithSortKey{internalClient}, nil
+}
+
+// AcquireLockWithContext holds the defined lock. The given context is passed
+// down to the underlying dynamoDB call.
+func (c *ClientWithSortKey) AcquireLockWithContext(ctx context.Context, partitionKey, sortKey string, opts ...AcquireLockOption) (*Lock, error) {
+	return c.acquireLockWithContext(ctx, partitionKey, opts...)
+}
+
+// GetWithContext finds out who owns the given lock, but does not acquire the
+// lock. It returns the metadata currently associated with the given lock. If
+// the client currently has the lock, it will return the lock, and operations
+// such as releaseLock will work. However, if the client does not have the lock,
+// then operations like releaseLock will not work (after calling GetWithContext,
+// the caller should check lockItem.isExpired() to figure out if it currently
+// has the lock.) If the context is canceled, it is going to return the context
+// error on local cache hit. The given context is passed down to the underlying
+// dynamoDB call.
+func (c *ClientWithSortKey) GetWithContext(ctx context.Context, partitionKey, sortKey string) (*Lock, error) {
+	return c.getWithContext(ctx, partitionKey)
+}
+
+// Sugar functions
+
+// Get finds out who owns the given lock, but does not acquire the lock. It
+// returns the metadata currently associated with the given lock. If the client
+// currently has the lock, it will return the lock, and operations such as
+// releaseLock will work. However, if the client does not have the lock, then
+// operations like releaseLock will not work (after calling Get, the caller
+// should check lockItem.isExpired() to figure out if it currently has the
+// lock.)
+func (c *ClientWithSortKey) Get(partitionKey, sortKey string) (*Lock, error) {
+	return c.GetWithContext(context.Background(), partitionKey, sortKey)
+}
+
+// AcquireLock holds the defined lock.
+func (c *ClientWithSortKey) AcquireLock(partitionKey, sortKey string, opts ...AcquireLockOption) (*Lock, error) {
+	return c.AcquireLockWithContext(context.Background(), partitionKey, sortKey, opts...)
+}


### PR DESCRIPTION
Simply adds the `ClientWithSortKey` wrapper, without actually changing `internalClient`. That will come in pieces in later commits.