### PR TITLE
Remove 'tableName' parameter from CreateTable.

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -74,7 +74,7 @@ func main() {
 	defer c.Close(context.Background())
 
 	log.Println("ensuring table exists")
-	_, err := c.CreateTable(context.Background(), "locks",
+	_, err := c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),

--- a/v3/client_bugs_test.go
+++ b/v3/client_bugs_test.go
@@ -42,7 +42,7 @@ func TestIssue56(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lockClient.CreateTable(context.Background(), "locksIssue56",
+	lockClient.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(1000),
 			WriteCapacityUnits: aws.Int64(1000),

--- a/v3/client_common.go
+++ b/v3/client_common.go
@@ -665,12 +665,12 @@ func (c *commonClient) heartbeat(ctx context.Context) {
 // because it takes a few minutes for DynamoDB to provision a new instance.
 // Also, if the table already exists, it will return an error. The given context
 // is passed down to the underlying dynamoDB call.
-func (c *commonClient) CreateTable(ctx context.Context, tableName string, opts ...CreateTableOption) (*dynamodb.CreateTableOutput, error) {
+func (c *commonClient) CreateTable(ctx context.Context, opts ...CreateTableOption) (*dynamodb.CreateTableOutput, error) {
 	if c.isClosed() {
 		return nil, ErrClientClosed
 	}
 	createTableOptions := &createDynamoDBTableOptions{
-		tableName:        tableName,
+		tableName:        c.tableName,
 		billingMode:      "PAY_PER_REQUEST",
 		partitionKeyName: c.partitionKeyName,
 	}

--- a/v3/client_heartbeat_test.go
+++ b/v3/client_heartbeat_test.go
@@ -62,7 +62,7 @@ func TestHeartbeatHandover(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -154,7 +154,7 @@ func TestHeartbeatDataOps(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),

--- a/v3/client_session_monitor_test.go
+++ b/v3/client_session_monitor_test.go
@@ -43,7 +43,7 @@ func TestSessionMonitor(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -95,7 +95,7 @@ func TestSessionMonitorRemoveBeforeExpiration(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks-monitor",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -146,7 +146,7 @@ func TestSessionMonitorFullCycle(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),

--- a/v3/client_test.go
+++ b/v3/client_test.go
@@ -100,7 +100,7 @@ func TestClientBasicFlow(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -196,7 +196,7 @@ func TestReadLockContent(t *testing.T) {
 		defer c.Close(context.Background())
 
 		t.Log("ensuring table exists")
-		c.CreateTable(context.Background(), "locks",
+		c.CreateTable(context.Background(),
 			dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
@@ -253,7 +253,7 @@ func TestReadLockContent(t *testing.T) {
 		defer c.Close(context.Background())
 
 		t.Log("ensuring table exists")
-		c.CreateTable(context.Background(), "locks",
+		c.CreateTable(context.Background(),
 			dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 				ReadCapacityUnits:  aws.Int64(5),
 				WriteCapacityUnits: aws.Int64(5),
@@ -294,7 +294,7 @@ func TestReadLockContentAfterRelease(t *testing.T) {
 	defer c.Close(context.Background())
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -354,7 +354,7 @@ func TestReadLockContentAfterDeleteOnRelease(t *testing.T) {
 	defer c.Close(context.Background())
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -427,7 +427,7 @@ func TestFailIfLocked(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -460,7 +460,7 @@ func TestClientWithAdditionalAttributes(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -538,7 +538,7 @@ func TestDeleteLockOnRelease(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -590,7 +590,7 @@ func TestCustomRefreshPeriod(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -625,7 +625,7 @@ func TestCustomAdditionalTimeToWaitForLock(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -669,7 +669,7 @@ func TestClientClose(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -716,7 +716,7 @@ func TestClientClose(t *testing.T) {
 		t.Error("expected error missing (acquire after close):", err)
 	}
 	t.Log("create table after close")
-	if _, err := c.CreateTable(context.Background(), "createTableAfterClose"); err != dynamolock.ErrClientClosed {
+	if _, err := c.CreateTable(context.Background()); err != dynamolock.ErrClientClosed {
 		t.Error("expected error missing (create table after close):", err)
 	}
 }
@@ -737,7 +737,7 @@ func TestInvalidReleases(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -799,7 +799,7 @@ func TestClientWithDataAfterRelease(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),
@@ -854,7 +854,7 @@ func TestHeartbeatLoss(t *testing.T) {
 	}
 
 	t.Log("ensuring table exists")
-	c.CreateTable(context.Background(), "locks",
+	c.CreateTable(context.Background(),
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),

--- a/v3/doc.go
+++ b/v3/doc.go
@@ -51,7 +51,7 @@ limitations under the License.
 //	defer c.Close(context.Background())
 //
 //	log.Println("ensuring table exists")
-//	c.CreateTable(context.Background(), "locks",
+//	c.CreateTable(context.Background(),
 //		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 //			ReadCapacityUnits:  aws.Int64(5),
 //			WriteCapacityUnits: aws.Int64(5),


### PR DESCRIPTION
As the `tableName` is already supplied to the constructor of `commonClient`, the parameter to `createTable` is redundant.
