### PR TITLE
Add specialization to createTable.

### DIFF
--- a/v3/structs.go
+++ b/v3/structs.go
@@ -58,7 +58,5 @@ type releaseLockOptions struct {
 type createDynamoDBTableOptions struct {
 	billingMode           types.BillingMode
 	provisionedThroughput *types.ProvisionedThroughput
-	tableName             string
-	partitionKeyName      string
 	tags                  []types.Tag
 }


### PR DESCRIPTION
As per previous discussion, instead of having functions such as `commonClient.createTable` doing run-time checks for whether a sort key is present or not, we've instead put the burden on the caller to describe the table's schema. Thus, `commonClient.createTable` and `commonClient.CreateTable` now require an additional parameter of type `createTableSchema`, which will return the schema.

To allow for the specialization, both `Client` and `ClientWithSortKey` each now have their own `CreateTable` functions defined, which simply forward the passed arguments, as well as their schema-creating methods.