### PR TITLE
Add `releaseLock` and remove `client` in `Lock`.

### DIFF
--- a/v3/client_common.go
+++ b/v3/client_common.go
@@ -531,8 +531,13 @@ func (c *commonClient) putLockItemAndStartSessionMonitor(
 		return nil, parseDynamoDBError(err, "cannot store lock item: lock already acquired by other client")
 	}
 
+	releaseLock := func(ctx context.Context, lock *Lock) error {
+		_, err := c.ReleaseLock(ctx, lock)
+		return err
+	}
+
 	lockItem := &Lock{
-		client:               c,
+		releaseLock:          releaseLock,
 		partitionKey:         partitionKey,
 		data:                 newLockData,
 		deleteLockOnRelease:  deleteLockOnRelease,
@@ -609,8 +614,13 @@ func (c *commonClient) createLockItem(opt getLockOptions, item map[string]types.
 		}
 	}
 
+	releaseLock := func(ctx context.Context, lock *Lock) error {
+		_, err := c.ReleaseLock(ctx, lock)
+		return err
+	}
+
 	lockItem := &Lock{
-		client:               c,
+		releaseLock:          releaseLock,
 		partitionKey:         opt.partitionKey,
 		data:                 data,
 		deleteLockOnRelease:  opt.deleteLockOnRelease,


### PR DESCRIPTION
This removes the reference to `client` in `Lock`, which allows us to customize how we want the lock to be closed in the future. (i.e. `Client` would just use `partitionKey`, whereas `ClientWithSortKey` would use `sortKey` as well.)

