### PR TITLE
Make Lock expose record revision number

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -945,7 +945,7 @@ func (c *Client) GetWithContext(ctx context.Context, key string) (*Lock, error) 
 		return &Lock{}, nil
 	}
 
-	lockItem.updateRVN("", time.Time{}, lockItem.leaseDuration)
+	lockItem.updateRVN(lockItem.recordVersionNumber, time.Time{}, lockItem.leaseDuration)
 	return lockItem, nil
 }
 

--- a/v2/lock.go
+++ b/v2/lock.go
@@ -102,6 +102,13 @@ func (l *Lock) OwnerName() string {
 	return l.ownerName
 }
 
+func (l *Lock) RecordVersionNumber() string {
+	if l == nil {
+		return ""
+	}
+	return l.recordVersionNumber
+}
+
 // AdditionalAttributes returns the lock's additional data stored during
 // acquisition.
 func (l *Lock) AdditionalAttributes() map[string]types.AttributeValue {


### PR DESCRIPTION
Add a method to expose lock record revision number.

### Some context
We are planning to add some monitoring to ensure that there is an active leader by checking if the record revision number is constantly changing.