### PR TITLE
Fix code example `no new variables on left side of :=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ func main() {
 	defer c.Close()
 
 	log.Println("ensuring table exists")
-	_, err := c.CreateTable("locks",
+	_, err = c.CreateTable("locks",
 		dynamolock.WithProvisionedThroughput(&dynamodb.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),

--- a/v2/README.md
+++ b/v2/README.md
@@ -74,7 +74,7 @@ func main() {
 	defer c.Close()
 
 	log.Println("ensuring table exists")
-	_, err := c.CreateTable("locks",
+	_, err = c.CreateTable("locks",
 		dynamolock.WithProvisionedThroughput(&types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(5),
 			WriteCapacityUnits: aws.Int64(5),


### PR DESCRIPTION
There was an error in the code examples both for v1 and v2. That's a quick fix.