### PR TITLE
Invoke session monitor callback when unsuccessful in reaching danger zone, or beyond the danger zone

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -1051,6 +1051,7 @@ func (c *Client) lockSessionMonitorChecker(ctx context.Context,
 				lock.semaphore.Unlock()
 				if err != nil {
 					c.logger.Println(ctx, "cannot run session monitor because", err)
+					go lock.sessionMonitor.callback()
 					return
 				}
 				if timeUntilDangerZone <= 0 {


### PR DESCRIPTION
The current session monitor callback implementation, will not invoke any user-provided callbacks if the underlying lock has already expired. 

In case of these errors, we also want to invoke the callback. Otherwise, it will silently fail, and stop running the session monitor goroutine without any signal that it has done so.

We can see that `func (l *Lock) timeUntilDangerZoneEntered() (time.Duration, error) {` will return an error on lock expiration errors.